### PR TITLE
[UNIX] Remove quiet mode from UIX launch script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,7 @@ fi
 success "Deno for UIX was installed successfully to $Bold_Green$(tildify "$exe")!"
 
 # install UIX
-$exe install --global --root "$deno_install" --no-config --no-lock -f --import-map https://cdn.unyt.org/uix/importmap.json -Aq -n uix https://cdn.unyt.org/uix/run.ts
+$exe install --global --root "$deno_install" --no-config --no-lock -f --import-map https://cdn.unyt.org/uix/importmap.json -A -n uix https://cdn.unyt.org/uix/run.ts
 success "UIX CLI was installed successfully"
 
 # shell detection for persistent installation


### PR DESCRIPTION
This PR removes the quiet mode for UIX launches on UNIX-based systems. It allows the user to see lengthy download procedures that are especially involved during the first launch of the UIX CLI and therefore directly influence the first-time developer experience.